### PR TITLE
Fix ADV30 handling when volume is missing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ yfinance
 pandas
 numpy
 ib_insync
+pytest

--- a/tests/test_adv30.py
+++ b/tests/test_adv30.py
@@ -1,0 +1,12 @@
+import numpy as np
+import pandas as pd
+from tech_signals_ibkr import calc_ADV30
+
+def test_calc_adv30_no_volume():
+    df = pd.DataFrame({"close": [1, 2, 3]})
+    result = calc_ADV30(df)
+    assert np.isnan(result)
+
+def test_calc_adv30_with_volume():
+    df = pd.DataFrame({"volume": [10, 20, 30, 40, 50]})
+    assert calc_ADV30(df) == 30


### PR DESCRIPTION
## Summary
- add `calc_ADV30` helper in `tech_signals_ibkr.py`
- guard main logic under `main()` and call helper
- update ADV30 calculation to return `NaN` if there is no volume column
- include simple unit tests
- add pytest to requirements

## Testing
- `pip install -r requirements.txt` *(fails: No matching distribution found)*
- `python tests/test_adv30.py` *(fails: ModuleNotFoundError: No module named 'numpy')*